### PR TITLE
allow running in web pages using a meta tag

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -227,8 +227,8 @@ getAllowlist(extensionId).then(
   (allowlist) => {
     for (const addr of computeAllowlist(allowlist)) {
       const host = new RegExp(addr);
-      if (host.test(window.location.href)) {
-        // the url matches the allowlist
+      if (host.test(window.location.href) || document.querySelector('meta[name="codeium:type"]')) {
+        // the url matches the allowlist or meta tag is found
         addMonacoInject();
         addCodeMirror5GlobalInject();
         addCodeMirror5LocalInject();

--- a/src/script.ts
+++ b/src/script.ts
@@ -229,6 +229,7 @@ getAllowlist(extensionId).then(
       const host = new RegExp(addr);
       if (host.test(window.location.href) || document.querySelector('meta[name="codeium:type"]')) {
         // the url matches the allowlist or meta tag is found
+        // TODO: restrict injection type by the value of the content attribute (comma-separated list). see https://github.com/Exafunction/codeium-chrome/issues/28
         addMonacoInject();
         addCodeMirror5GlobalInject();
         addCodeMirror5LocalInject();


### PR DESCRIPTION
if a web page needs to run the extension without being in the allowlist, this meta tag would trigger activating the functionality of the extension:

```
<meta name="codeium:type" content="monaco">
```

This is a demo: https://codeium.livecodes.pages.dev/

see https://github.com/Exafunction/codeium-chrome/issues/28