### PR TITLE
add LiveCodes to list of supported websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _Free, ultrafast code autocomplete for Chrome_
 - [Google Colab](https://colab.research.google.com/)
 - [JSFiddle](https://jsfiddle.net/)
 - [JupyterLab 3.x/Jupyter notebooks](https://jupyter.org/)
-- [LiveCodes](https://livecodes.io/) (including [self-hosted](https://livecodes.io/docs/features/self-hosting) apps)
+- [LiveCodes](https://livecodes.io/)
 - [Paperspace](https://www.paperspace.com/)
 - [Quadratic](https://www.quadratichq.com/)
 - [StackBlitz](https://stackblitz.com/)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _Free, ultrafast code autocomplete for Chrome_
 - [Quadratic](https://www.quadratichq.com/)
 - [StackBlitz](https://stackblitz.com/)
 
-Contributions are welcome! Feel free to submit pull requests and issues related to the extension.
+Contributions are welcome! Feel free to submit pull requests and issues related to the extension or to add links to supported websites.
 
 🔗 [Original Chrome extension launch announcement](https://codeium.com/blog/codeium-chrome-extension-launch)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ _Free, ultrafast code autocomplete for Chrome_
 - [Google Colab](https://colab.research.google.com/)
 - [JSFiddle](https://jsfiddle.net/)
 - [JupyterLab 3.x/Jupyter notebooks](https://jupyter.org/)
+- [LiveCodes](https://livecodes.io/) (including [self-hosted](https://livecodes.io/docs/features/self-hosting) apps)
 - [Paperspace](https://www.paperspace.com/)
 - [Quadratic](https://www.quadratichq.com/)
 - [StackBlitz](https://stackblitz.com/)


### PR DESCRIPTION
Now [LiveCodes](https://livecodes.io/) and any of its [self-hosted](https://livecodes.io/docs/features/self-hosting/) apps are supported based on #29 (without having to add anything to allowlist).

It is documented here: https://livecodes.io/docs/features/ai

This PR adds LiveCodes to list of supported sites in the README.

Thank you for providing such a great product.