### PR TITLE
Fix the Monaco undefined error on some websites

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -74,12 +74,7 @@ const addMonacoInject = () =>
             break;
           }
         }
-
-        // even if the monaco instance can't be registered with the completion provider,
-        // please still set _codeium_monaco, or _codeium_monaco.languages will cause an error
-
         this._codeium_monaco = _monaco;
-
         const completionProvider = new MonacoCompletionProvider(extensionId, injectMonaco);
         if (!_monaco?.languages?.registerInlineCompletionsProvider) {
           return;

--- a/src/script.ts
+++ b/src/script.ts
@@ -75,8 +75,13 @@ const addMonacoInject = () =>
           }
         }
 
+        // even if the monaco instance can't be registered with the completion provider,
+        // please still set _codeium_monaco, or _codeium_monaco.languages will cause an error
+
+        this._codeium_monaco = _monaco;
+
         const completionProvider = new MonacoCompletionProvider(extensionId, injectMonaco);
-        if (!_monaco.languages.registerInlineCompletionsProvider) {
+        if (!_monaco?.languages?.registerInlineCompletionsProvider) {
           return;
         }
         setTimeout(() => {
@@ -98,7 +103,6 @@ const addMonacoInject = () =>
           });
           console.log('Activated Codeium: Monaco');
         });
-        this._codeium_monaco = _monaco;
       },
     },
   });


### PR DESCRIPTION
I came across this error on discuss post on leetcode.cn, it uses a monaco editor to type some text inputs for replies, for example, click the green button "reply the discussion" in [this post](https://leetcode.cn/circle/discuss/LrkdBo/), a monaco editor will be rendered but I can't focus or type anything. Because of the early return logic, `this._codeium_monaco` is not set, if the get method of `monaco` is called, it may throw an undefined error.

<img width="1355" alt="Screenshot 2024-02-11 at 2 29 17 AM" src="https://github.com/Exafunction/codeium-chrome/assets/10118462/931d6d05-c643-40d6-ade8-aef2e1a04fb0">
