### PR TITLE
[WIP] Feat: show tab-specific icon status and turn on/off completion on each page manually

### DIFF
--- a/src/codemirror.ts
+++ b/src/codemirror.ts
@@ -113,6 +113,9 @@ export class CodeMirrorManager {
     relativePath: string | undefined,
     createDisposables: (() => IDisposable[]) | undefined
   ): Promise<void> {
+    if (!window.codeium_enabled) {
+      return;
+    }
     const clientSettings = await this.client.clientSettingsPoller.clientSettings;
     if (clientSettings.apiKey === undefined) {
       return;

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,6 +1,20 @@
-const s = document.createElement('script');
-s.src = chrome.runtime.getURL('script.js?') + new URLSearchParams({ id: chrome.runtime.id });
-s.onload = function () {
-  (this as HTMLScriptElement).remove();
-};
-(document.head || document.documentElement).prepend(s);
+// avoid injecting the script into redundant frames
+if (window.top === window.self) {
+  const s = document.createElement('script');
+  s.src = chrome.runtime.getURL('script.js?') + new URLSearchParams({ id: chrome.runtime.id });
+  s.onload = function () {
+    (this as HTMLScriptElement).remove();
+  };
+  (document.head || document.documentElement).prepend(s);
+
+  let codeiumEnabled = true;
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'codeium_toggle') {
+      codeiumEnabled = !codeiumEnabled;
+      window.dispatchEvent(
+        new CustomEvent('CodeiumEvent', { detail: { enabled: codeiumEnabled } })
+      );
+    }
+  });
+}

--- a/src/monacoCompletionProvider.ts
+++ b/src/monacoCompletionProvider.ts
@@ -406,6 +406,7 @@ export class MonacoCompletionProvider implements monaco.languages.InlineCompleti
     model: monaco.editor.ITextModel,
     position: monaco.Position
   ): Promise<monaco.languages.InlineCompletions | undefined> {
+    if (!window.codeium_enabled) return;
     const clientSettings = await this.client.clientSettingsPoller.clientSettings;
     if (clientSettings.apiKey === undefined) {
       return;
@@ -454,6 +455,7 @@ export class MonacoCompletionProvider implements monaco.languages.InlineCompleti
       )
       .filter((item): item is monaco.languages.InlineCompletion => item !== undefined);
     void chrome.runtime.sendMessage(this.extensionId, { type: 'success' });
+    console.log(items);
     return { items };
   }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -58,3 +58,26 @@ export async function unhealthy(message: string): Promise<void> {
     setStorageItem('lastError', { message: message }),
   ]);
 }
+
+export async function update_tab_icon(tabId: number | undefined, status: string): Promise<void> {
+  const iconType = status === 'active' ? 'codeium_square_logo' : 'codeium_square_inactive';
+  const text = status === 'active' ? '' : status;
+
+  await Promise.all([
+    chrome.action.setBadgeText({
+      tabId: tabId,
+      text,
+    }),
+    chrome.action.setIcon({
+      tabId: tabId,
+      path: {
+        16: `/icons/16/${iconType}.png`,
+        32: `/icons/32/${iconType}.png`,
+        48: `/icons/48/${iconType}.png`,
+        128: `/icons/128/${iconType}.png`,
+      },
+    }),
+    chrome.action.setTitle({ title: `Codeium ${status}`, tabId: tabId }),
+    clearLastError(),
+  ]);
+}

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -21,7 +21,7 @@
       "matches": ["<all_urls>"]
     }
   ],
-  "permissions": ["storage"],
+  "permissions": ["storage", "tabs", "activeTab", "contextMenus"],
   "options_ui": {
     "page": "options.html",
     "open_in_tab": false,


### PR DESCRIPTION
Add a contextMenu option to control the behavior on the current tab:
![image](https://github.com/Exafunction/codeium-chrome/assets/10118462/198c1a22-7abf-42eb-8912-b1b80d107af9)


Three status:

1. <img width="27" alt="image" src="https://github.com/Exafunction/codeium-chrome/assets/10118462/fad98d24-4f4d-4eca-8bb8-612bfbec09f6"> idle: The extension is enabled, but the URL is not in white list or no editor can be injected
2. <img width="38" alt="image" src="https://github.com/Exafunction/codeium-chrome/assets/10118462/f5fb59b7-7fde-4f16-a3be-160a7a7d2ab1"> off: the extension is disabled by the user
3. <img width="31" alt="image" src="https://github.com/Exafunction/codeium-chrome/assets/10118462/b6111606-c552-4773-b93b-034bbb7747a0"> active: the completion is working on this page.

Implementation issues:

contentScript.ts and the injected script.ts are running independently, so we have to construct so many messages to communicate between different environments. Temporarily, the "disabled" feature is hacked by passing the global variable `codeium_disabled` and let the completion provider in Monaco/CodeMirror be dummy when observing `codeium_disabled` become `false`, instead of implementing a real clean up script to unregister all completion handlers. It may be problematic, for example, Colab supports inline completion for some eligible users. If we turn off the Codeium extension, the built-in colab completion is also disabled.





For issue #49 (for now, only 1 and 2 are done)